### PR TITLE
✨ preタグの後のスペースが広すぎたので、調整

### DIFF
--- a/styles/global.css
+++ b/styles/global.css
@@ -43,6 +43,9 @@ ul {
     line-height: 2em;
 }
 
+article pre {
+    overflow: inherit;
+}
 article h2 {
     margin-top: 2.3em;
     margin-bottom: 1em;


### PR DESCRIPTION
## 修正前

![image](https://github.com/Tatsurou-Yajima/blog-built-with-Next.js/assets/44424270/fd72a083-4d51-47bd-9f49-f999a2e0b4e8)


## 修正後

![image](https://github.com/Tatsurou-Yajima/blog-built-with-Next.js/assets/44424270/acbd2e9e-f513-44b8-ad94-61dda31a9e1d)
